### PR TITLE
없어진 변수 대체

### DIFF
--- a/DolgubonsLazyWritCreatorKRPatch/DolgubonsLazyWritCreatorKRPatch.txt
+++ b/DolgubonsLazyWritCreatorKRPatch/DolgubonsLazyWritCreatorKRPatch.txt
@@ -2,7 +2,7 @@
 ## Description: KR Patch for Dolgubon's Lazy Writ Crafter
 ## APIVersion: 100027
 ## Author: @Whya5448 @DiPoon
-## Version: 1.1.0
+## Version: 1.1.1
 ## DependsOn: DolgubonsLazyWritCreator EsoKR
 
 DolgubonsLazyWritCreatorKRPatch.lua

--- a/DolgubonsLazyWritCreatorKRPatch/DolgubonsLazyWritCreatorKRPatch.txt
+++ b/DolgubonsLazyWritCreatorKRPatch/DolgubonsLazyWritCreatorKRPatch.txt
@@ -1,8 +1,8 @@
 ﻿## Title: KR Patch for Dolgubon's Lazy Writ Crafter
 ## Description: KR Patch for Dolgubon's Lazy Writ Crafter
 ## APIVersion: 100027
-## Author: @Whya5448
-## Version: 1.1.0-e07ae48
+## Author: @Whya5448 @DiPoon
+## Version: 1.1.0
 ## DependsOn: DolgubonsLazyWritCreator EsoKR
 
 DolgubonsLazyWritCreatorKRPatch.lua

--- a/DolgubonsLazyWritCreatorKRPatch/ReticleChanges.lua
+++ b/DolgubonsLazyWritCreatorKRPatch/ReticleChanges.lua
@@ -56,8 +56,8 @@ if EsoKR and EsoKR:isKorean() then
 end
 
 
-local oldInteract = FISHING_MANAGER.StartInteraction
-FISHING_MANAGER.StartInteraction = function(...)
+local oldInteract = INTERACTIVE_WHEEL_MANAGER.StartInteraction
+INTERACTIVE_WHEEL_MANAGER.StartInteraction = function(...)
 	if WritCreater:GetSettings().stealProtection then
 		local _, hasWrits = WritCreater.writSearch()
 		if not hasWrits then


### PR DESCRIPTION
FISHING_MANAGER 가 삭제된 것으로 보입니다. esoui 최신 풀에서 검색이 안됩니다. 다른 에드온에서 사용하는 변수로 대체합니다.

아래 이슈 해결 방법입니다.
https://github.com/DIPOON/KR-Patch-for-Dolgubon-s-Lazy-Writ-Crafter/issues